### PR TITLE
Run on `ubuntu-latest` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A job has several options to specify:
 job. For instance, `"github.ref == 'refs/heads/master'"` would only run the job when the
 current branch is master. By default this condition is empty to always run the job.
 * Which container to run the job on: `Job(runs_on="...")` specifies the name of the container.
-By default this is `ubuntu-18.04`.
+By default this is `ubuntu-latest`.
 * Which steps to run: `Job(steps=[...])` specifies the steps to execute for this job.
 Each step must be a `RunStep` or `UsesStep` instance or subclass thereof. By default `gadk`
 adds a checkout v2 step and prepends it to the list of steps. This is a useful
@@ -118,7 +118,7 @@ class MyWorkflow(Workflow):
         self.jobs["test"] = Job(
             steps=[RunStep("pytest"), RunStep("mypy")],  # Run 2 shell commands, one after the other.
             # condition=""  # No condition specified to run always.
-            # runs_on="ubuntu-18.04"  # Run on the default container as specified by gadk.
+            # runs_on="ubuntu-latest"  # Run on the default container as specified by gadk.
             env={"PYTHONPATH": "."},  # Add 1 additional environment variable.
             # needs=None  # No other jobs need to be executed before this job.
             # default_checkout=True   # Prepend an additional step to checkout the repository.

--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -145,7 +145,7 @@ class Job(Yamlable):
         self,
         *,
         condition: str = "",
-        runs_on: str = "ubuntu-18.04",
+        runs_on: str = "ubuntu-latest",
         steps: Optional[List[Step]] = None,
         needs: Optional[List[str]] = None,
         env: Optional[EnvVars] = None,

--- a/tests/integration/examples/abstract/expected.yml
+++ b/tests/integration/examples/abstract/expected.yml
@@ -3,7 +3,7 @@ name: bar service
 'on': {}
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: make name="bar" build
@@ -14,9 +14,8 @@ name: foo service
 'on': {}
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: make name="foo" build
     - run: make name="foo" test
-

--- a/tests/integration/examples/artifacts/expected.yml
+++ b/tests/integration/examples/artifacts/expected.yml
@@ -3,7 +3,7 @@ name: my service workflow
 'on': {}
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: make build
@@ -12,7 +12,7 @@ jobs:
         name: code-archive
         path: build/code.zip
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v2
@@ -20,4 +20,3 @@ jobs:
         name: code-archive
         path: build/code.zip
     - run: scp build/code.zip
-

--- a/tests/integration/examples/custom_step/expected.yml
+++ b/tests/integration/examples/custom_step/expected.yml
@@ -3,10 +3,9 @@ name: foobar service
 'on': {}
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: make build
     - run: make lint verbose="1"
     - run: make test verbose="1" suite="unit"
-

--- a/tests/integration/examples/simple/expected.yml
+++ b/tests/integration/examples/simple/expected.yml
@@ -17,10 +17,9 @@ concurrency:
   workflow_dispatch: null
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: make build
     - run: make lint
     - run: make test
-


### PR DESCRIPTION
As per the sole commit:

> It doesn't make sense to pin to an old version of Ubuntu as a default environment. Github Actions provides `ubuntu-latest` as an alias for the latest release. This commit updates the default to this alias.
