### PR TITLE
Add support for matrix jobs

### DIFF
--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod, ABC
+from collections.abc import Sequence
 from typing import Any, Dict, Optional, Iterable, List, Union
 
 from .constants import ACTION_CHECKOUT, ACTION_DOWNLOAD, ACTION_UPLOAD
@@ -185,6 +186,7 @@ class Job(Yamlable):
         name: Optional[str] = None,
         condition: str = "",
         runs_on: str = "ubuntu-latest",
+        matrix: Optional[Dict[str, Sequence]] = None,
         steps: Optional[List[Step]] = None,
         needs: Optional[Union[List[str], str]] = None,
         outputs: Dict[str, Union[str, Expression]] = None,
@@ -195,6 +197,7 @@ class Job(Yamlable):
         self._name = name
         self._if: str = condition or ""
         self._runs_on: str = runs_on
+        self._matrix = matrix
         self._steps: List[Step] = steps or []
         self._needs: Union[List[str], str] = needs or []
         self._outputs: Dict[str, Union[str, Expression]] = outputs
@@ -221,6 +224,8 @@ class Job(Yamlable):
         if self._needs:
             job["needs"] = self._needs
         job["runs-on"] = self._runs_on
+        if self._matrix is not None:
+            job["strategy"] = {"matrix": self._matrix}
         if self._outputs is not None:
             job["outputs"] = {
                 output: value.to_yaml() if isinstance(value, Yamlable) else value

--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -188,6 +188,7 @@ class Job(Yamlable):
         runs_on: str = "ubuntu-latest",
         matrix: Optional[Dict[str, Sequence]] = None,
         fail_fast: Optional[bool] = None,
+        max_parallel: Optional[int] = None,
         steps: Optional[List[Step]] = None,
         needs: Optional[Union[List[str], str]] = None,
         outputs: Dict[str, Union[str, Expression]] = None,
@@ -201,8 +202,12 @@ class Job(Yamlable):
         if matrix is None and fail_fast is not None:
             raise ValueError('"fail_fast" requires "matrix"')
 
+        if matrix is None and max_parallel is not None:
+            raise ValueError('"max_parallel" requires "matrix"')
+
         self._matrix = matrix
         self._fail_fast = fail_fast
+        self._max_parallel = max_parallel
         self._steps: List[Step] = steps or []
         self._needs: Union[List[str], str] = needs or []
         self._outputs: Dict[str, Union[str, Expression]] = outputs
@@ -233,6 +238,8 @@ class Job(Yamlable):
             job["strategy"] = {"matrix": self._matrix}
             if self._fail_fast is not None:
                 job["strategy"]["fail-fast"] = self._fail_fast
+            if self._max_parallel is not None:
+                job["strategy"]["max-parallel"] = self._max_parallel
         if self._outputs is not None:
             job["outputs"] = {
                 output: value.to_yaml() if isinstance(value, Yamlable) else value

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -108,6 +108,41 @@ class TestJob:
         assert "outputs" in yaml
         assert yaml["outputs"] == {"string-output": "foo", "expr-output": "${{ bar }}"}
 
+    def test_matrix(self):
+        matrix = {"version": ["1.1", "2.2"], "env": ["dev", "prod"]}
+        job = Job(matrix=matrix)
+        yaml = job.to_yaml()
+        assert "strategy" in yaml
+        assert yaml["strategy"] == {"matrix": matrix}
+
+    def test_matrix_include(self):
+        matrix = {
+            "version": ["1.1", "2.2"],
+            "env": ["dev", "prod"],
+            "include": [
+                {"version": "1.1", "env": "prod"},
+                {"version": "2.2", "env": "dev"},
+                {"version": "2.2", "env": "prod"},
+            ],
+        }
+        job = Job(matrix=matrix)
+        yaml = job.to_yaml()
+        assert "strategy" in yaml
+        assert yaml["strategy"] == {"matrix": matrix}
+
+    def test_matrix_exclude(self):
+        matrix = {
+            "version": ["1.1", "2.2"],
+            "env": ["dev", "prod"],
+            "exclude": [
+                {"version": "2.2", "env": "prod"},
+            ],
+        }
+        job = Job(matrix=matrix)
+        yaml = job.to_yaml()
+        assert "strategy" in yaml
+        assert yaml["strategy"] == {"matrix": matrix}
+
 
 @pytest.mark.parametrize("step_cls, step_args, step_kwargs", [
     (RunStep, ("echo foo",), {}),

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -154,6 +154,13 @@ class TestJob:
         with pytest.raises(ValueError):
             Job(fail_fast=True)
 
+    def test_max_parallel(self):
+        matrix = {"a": [1, 2]}
+        job = Job(matrix=matrix, max_parallel=2)
+        yaml = job.to_yaml()
+        assert "strategy" in yaml
+        assert yaml["strategy"] == {"matrix": matrix, "max-parallel": 2}
+
 
 @pytest.mark.parametrize("step_cls, step_args, step_kwargs", [
     (RunStep, ("echo foo",), {}),

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -143,6 +143,17 @@ class TestJob:
         assert "strategy" in yaml
         assert yaml["strategy"] == {"matrix": matrix}
 
+    def test_fail_fast(self):
+        matrix = {"a": [1, 2]}
+        job = Job(matrix=matrix, fail_fast=True)
+        yaml = job.to_yaml()
+        assert "strategy" in yaml
+        assert yaml["strategy"] == {"matrix": matrix, "fail-fast": True}
+
+    def test_fail_fast_without_matrix(self):
+        with pytest.raises(ValueError):
+            Job(fail_fast=True)
+
 
 @pytest.mark.parametrize("step_cls, step_args, step_kwargs", [
     (RunStep, ("echo foo",), {}),


### PR DESCRIPTION
This PR adds support for matrix jobs, including `fail-fast` and `max-parallel`.
