### PR TITLE
Support checkout depth

### DIFF
--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -194,6 +194,7 @@ class Job(Yamlable):
         outputs: Dict[str, Union[str, Expression]] = None,
         env: Optional[EnvVars] = None,
         default_checkout: bool = True,
+        fetch_depth: Optional[int] = None,
     ) -> None:
         super().__init__()
         self._name = name
@@ -213,7 +214,11 @@ class Job(Yamlable):
         self._outputs: Dict[str, Union[str, Expression]] = outputs
         self._env: EnvVars = env or {}
         if default_checkout:
-            self._steps.insert(0, UsesStep(action=ACTION_CHECKOUT))
+            checkout_step_args = {"action": ACTION_CHECKOUT}
+            if fetch_depth is not None:
+                checkout_step_args["with_args"] = {"fetch-depth": fetch_depth}
+
+            self._steps.insert(0, UsesStep(**checkout_step_args))
 
     def __repr__(self):
         repr_ = f"<{type(self).__name__}"

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -168,6 +168,20 @@ class TestJob:
         assert "strategy" in yaml
         assert yaml["strategy"] == {"matrix": matrix, "max-parallel": 2}
 
+    @pytest.mark.parametrize('default_checkout', [None, True, False])
+    def test_default_checkout(self, default_checkout):
+        job_args = {"steps": [RunStep("echo hello")]}
+        if default_checkout is not None:
+            job_args["default_checkout"] = default_checkout
+
+        job = Job(**job_args)
+        yaml = job.to_yaml()
+        assert "steps" in yaml
+        if default_checkout is None or default_checkout is True:
+            assert yaml["steps"][0] == {"uses": "actions/checkout@v3"}
+        else:
+            assert {"uses": "actions/checkout@v3"} not in yaml["steps"]
+
 
 @pytest.mark.parametrize("step_cls, step_args, step_kwargs", [
     (RunStep, ("echo foo",), {}),

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -182,6 +182,25 @@ class TestJob:
         else:
             assert {"uses": "actions/checkout@v3"} not in yaml["steps"]
 
+    @pytest.mark.parametrize('fetch_depth', [None, 0, 1])
+    def test_fetch_depth(self, fetch_depth):
+        job_args = {"steps": [RunStep("echo hello")]}
+        if fetch_depth is not None:
+            job_args["fetch_depth"] = fetch_depth
+
+        job = Job(**job_args)
+        yaml = job.to_yaml()
+        assert "steps" in yaml
+
+        checkout_step = yaml["steps"][0]
+        if fetch_depth is not None:
+            assert checkout_step == {
+                "uses": "actions/checkout@v3",
+                "with": {"fetch-depth": fetch_depth},
+            }
+        else:
+            assert "with" not in checkout_step
+
 
 @pytest.mark.parametrize("step_cls, step_args, step_kwargs", [
     (RunStep, ("echo foo",), {}),


### PR DESCRIPTION
In order to support a particular use case, this commit adds support for the `fetch-depth` parameter to `actions/checkout` when forming the `default_checkout` step.
