### PR TITLE
Add name to artifact upload and download steps

### DIFF
--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -224,6 +224,7 @@ class Artifact:
         step_name: Optional[str] = None,
         *,
         if_no_files_found: Optional[Literal["error", "warn", "ignore"]] = None,
+        **kwargs,
     ) -> UsesStep:
         args = {"name": self._name, "path": self.path}
         if if_no_files_found is not None:
@@ -232,9 +233,9 @@ class Artifact:
         if step_name is None:
             step_name = f"Upload artifact '{self._name}'"
 
-        return UsesStep(name=step_name, action=ACTION_UPLOAD, with_args=args)
+        return UsesStep(name=step_name, action=ACTION_UPLOAD, with_args=args, **kwargs)
 
-    def as_download(self, step_name: Optional[str] = None) -> UsesStep:
+    def as_download(self, step_name: Optional[str] = None, **kwargs) -> UsesStep:
         if step_name is None:
             step_name = f"Download artifact '{self._name}'"
 
@@ -242,6 +243,7 @@ class Artifact:
             name=step_name,
             action=ACTION_DOWNLOAD,
             with_args={"name": self._name, "path": self.path},
+            **kwargs,
         )
 
 

--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -221,12 +221,16 @@ class Artifact:
 
     def as_upload(self) -> UsesStep:
         return UsesStep(
-            action=ACTION_UPLOAD, with_args={"name": self._name, "path": self.path}
+            name=f"Upload artifact '{self._name}'",
+            action=ACTION_UPLOAD,
+            with_args={"name": self._name, "path": self.path},
         )
 
     def as_download(self) -> UsesStep:
         return UsesStep(
-            action=ACTION_DOWNLOAD, with_args={"name": self._name, "path": self.path}
+            name=f"Download artifact '{self._name}'",
+            action=ACTION_DOWNLOAD,
+            with_args={"name": self._name, "path": self.path},
         )
 
 

--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod, ABC
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional, Iterable, List, Union
+from typing import Any, Dict, Literal, Mapping, Optional, Iterable, List, Union
 
 from .constants import ACTION_CHECKOUT, ACTION_DOWNLOAD, ACTION_UPLOAD
 
@@ -219,11 +219,15 @@ class Artifact:
         self._name: str = name
         self.path: str = path
 
-    def as_upload(self) -> UsesStep:
+    def as_upload(
+        self, *, if_no_files_found: Optional[Literal["error", "warn", "ignore"]] = None
+    ) -> UsesStep:
+        args = {"name": self._name, "path": self.path}
+        if if_no_files_found is not None:
+            args["if-no-files-found"] = if_no_files_found
+
         return UsesStep(
-            name=f"Upload artifact '{self._name}'",
-            action=ACTION_UPLOAD,
-            with_args={"name": self._name, "path": self.path},
+            name=f"Upload artifact '{self._name}'", action=ACTION_UPLOAD, with_args=args
         )
 
     def as_download(self) -> UsesStep:

--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -220,19 +220,26 @@ class Artifact:
         self.path: str = path
 
     def as_upload(
-        self, *, if_no_files_found: Optional[Literal["error", "warn", "ignore"]] = None
+        self,
+        step_name: Optional[str] = None,
+        *,
+        if_no_files_found: Optional[Literal["error", "warn", "ignore"]] = None,
     ) -> UsesStep:
         args = {"name": self._name, "path": self.path}
         if if_no_files_found is not None:
             args["if-no-files-found"] = if_no_files_found
 
-        return UsesStep(
-            name=f"Upload artifact '{self._name}'", action=ACTION_UPLOAD, with_args=args
-        )
+        if step_name is None:
+            step_name = f"Upload artifact '{self._name}'"
 
-    def as_download(self) -> UsesStep:
+        return UsesStep(name=step_name, action=ACTION_UPLOAD, with_args=args)
+
+    def as_download(self, step_name: Optional[str] = None) -> UsesStep:
+        if step_name is None:
+            step_name = f"Download artifact '{self._name}'"
+
         return UsesStep(
-            name=f"Download artifact '{self._name}'",
+            name=step_name,
             action=ACTION_DOWNLOAD,
             with_args={"name": self._name, "path": self.path},
         )

--- a/tests/integration/examples/artifacts/expected.yml
+++ b/tests/integration/examples/artifacts/expected.yml
@@ -7,7 +7,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: make build
-    - uses: actions/upload-artifact@v3
+    - name: Upload artifact 'code-archive'
+      uses: actions/upload-artifact@v3
       with:
         name: code-archive
         path: build/code.zip
@@ -15,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
+    - name: Download artifact 'code-archive'
+      uses: actions/download-artifact@v3
       with:
         name: code-archive
         path: build/code.zip

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from textwrap import dedent
-from typing import Union
+from typing import Literal, Optional, Union
 
 import pytest
 
@@ -331,5 +331,26 @@ class TestArtifact:
                 name=f"Download artifact 'my-artifact'",
                 action=ACTION_DOWNLOAD,
                 with_args={"name": "my-artifact", "path": "foo/bar"},
+            )
+        )
+
+    @pytest.mark.parametrize("if_no_files_found", [None, "error", "warn", "ignore"])
+    def test_if_no_files_found(
+        self, if_no_files_found: Optional[Literal["error", "warn", "ignore"]]
+    ):
+        artifact = Artifact(name="my-artifact", path="foo/bar")
+        if if_no_files_found is None:
+            upload_step = artifact.as_upload()
+        else:
+            upload_step = artifact.as_upload(if_no_files_found=if_no_files_found)
+
+        expected_args = {"name": "my-artifact", "path": "foo/bar"}
+        if if_no_files_found is not None:
+            expected_args["if-no-files-found"] = if_no_files_found
+        assert vars(upload_step) == vars(
+            UsesStep(
+                name=f"Upload artifact 'my-artifact'",
+                action=ACTION_UPLOAD,
+                with_args=expected_args,
             )
         )

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -316,6 +316,7 @@ class TestArtifact:
         assert isinstance(upload_step, UsesStep)
         assert vars(upload_step) == vars(
             UsesStep(
+                name=f"Upload artifact 'my-artifact'",
                 action=ACTION_UPLOAD,
                 with_args={"name": "my-artifact", "path": "foo/bar"},
             )
@@ -327,6 +328,7 @@ class TestArtifact:
         assert isinstance(download_step, UsesStep)
         assert vars(download_step) == vars(
             UsesStep(
+                name=f"Download artifact 'my-artifact'",
                 action=ACTION_DOWNLOAD,
                 with_args={"name": "my-artifact", "path": "foo/bar"},
             )

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -307,3 +307,27 @@ class TestCacheStep:
                 "restore-keys": "cache-deps-",
             },
         }
+
+
+class TestArtifact:
+    def test_upload(self):
+        artifact = Artifact(name="my-artifact", path="foo/bar")
+        upload_step = artifact.as_upload()
+        assert isinstance(upload_step, UsesStep)
+        assert vars(upload_step) == vars(
+            UsesStep(
+                action=ACTION_UPLOAD,
+                with_args={"name": "my-artifact", "path": "foo/bar"},
+            )
+        )
+
+    def test_download(self):
+        artifact = Artifact(name="my-artifact", path="foo/bar")
+        download_step = artifact.as_download()
+        assert isinstance(download_step, UsesStep)
+        assert vars(download_step) == vars(
+            UsesStep(
+                action=ACTION_DOWNLOAD,
+                with_args={"name": "my-artifact", "path": "foo/bar"},
+            )
+        )


### PR DESCRIPTION
Currently, steps generated by artifacts have unhelpful names referencing the action used. This PR adds helpful names to these steps so that steps for different artifacts can be distinguished.
