### PR TITLE
Use literal style for multi-line strings

### DIFF
--- a/gadk/utils.py
+++ b/gadk/utils.py
@@ -23,6 +23,18 @@ class _NoAliasDumper(yaml.SafeDumper):
         return True
 
 
+def represent_str(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+    """Represent multi-line strings as literal scalars.
+
+    Based on https://stackoverflow.com/a/33300001/250673
+    """
+    return (
+        dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+        if len(data.splitlines()) > 1
+        else dumper.represent_str(data)
+    )
+
+
 def dump_yaml(value: Any) -> str:
     """
     Dump value as Yaml.
@@ -33,6 +45,7 @@ def dump_yaml(value: Any) -> str:
         * Yaml anchors and aliases are disabled as Github Actions does not support them.
     """
 
+    yaml.representer.SafeRepresenter.add_representer(str, represent_str)
     # Note: dump_all uses a subclass of the safe yaml dumper. If tools mark this line as insecure,
     # then they probably don't follow the inheritance tree.
     return yaml.dump_all([value], sort_keys=False, Dumper=_NoAliasDumper, width=120)


### PR DESCRIPTION
As per the sole commit:

> By default, PyYAML uses "quoted style" for all strings regardless of content. This means that, in the GitHub Actions context, multi-line strings such as shell scripts composed of multiple commands are formatted poorly in the generated YAML. In order to improve the formatting of the generated YAML in this scenario, this commit overrides the "representer" function for strings such that multi-line strings use "literal style", like this:
>
>     key: |
>       value line 1
>       value line 2
