### PR TITLE
Allow downloading an artifact to a different path

### DIFF
--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -235,14 +235,21 @@ class Artifact:
 
         return UsesStep(name=step_name, action=ACTION_UPLOAD, with_args=args, **kwargs)
 
-    def as_download(self, step_name: Optional[str] = None, **kwargs) -> UsesStep:
+    def as_download(
+        self,
+        step_name: Optional[str] = None,
+        dest_path: Optional[str] = None,
+        **kwargs,
+    ) -> UsesStep:
         if step_name is None:
             step_name = f"Download artifact '{self._name}'"
+
+        path = dest_path if dest_path is not None else self.path
 
         return UsesStep(
             name=step_name,
             action=ACTION_DOWNLOAD,
-            with_args={"name": self._name, "path": self.path},
+            with_args={"name": self._name, "path": path},
             **kwargs,
         )
 

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -334,6 +334,18 @@ class TestArtifact:
             )
         )
 
+    def test_download_dest_path(self):
+        artifact = Artifact(name="my-artifact", path="foo/bar")
+        download_step = artifact.as_download(dest_path="baz")
+        assert isinstance(download_step, UsesStep)
+        assert vars(download_step) == vars(
+            UsesStep(
+                name=f"Download artifact 'my-artifact'",
+                action=ACTION_DOWNLOAD,
+                with_args={"name": "my-artifact", "path": "baz"},
+            )
+        )
+
     @pytest.mark.parametrize("if_no_files_found", [None, "error", "warn", "ignore"])
     def test_if_no_files_found(
         self, if_no_files_found: Optional[Literal["error", "warn", "ignore"]]


### PR DESCRIPTION
Sometimes an artifact path is a glob pattern so it doesn't make sense to use that as the download path. This PR adds a parameter to `Artifact.as_download` allowing a different path to be specified.
