### PR TITLE
[Tooling] Add single quotes around generated cron expressions

### DIFF
--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -388,7 +388,7 @@ class Workflow(Yamlable):
         elif "workflow_dispatch" in self._on:
             del self._on["workflow_dispatch"]
         if schedules is not None:
-            self._on["schedule"] = [{"cron": schedule} for schedule in schedules]
+            self._on["schedule"] = [{"cron": f"'{schedule}'"} for schedule in schedules]
         elif "schedule" in self._on:
             del self._on["schedule"]
 

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -126,7 +126,7 @@ class TestWorkflowOn:
     def test_on_schedule(self):
         workflow = Workflow("foo")
         workflow.on(schedules=["0 7 * * 1-5"])  # Monday-Friday at 07:00
-        assert workflow.to_yaml() == {"on": {"schedule": [{"cron": "0 7 * * 1-5"}]}}
+        assert workflow.to_yaml() == {"on": {"schedule": [{"cron": "'0 7 * * 1-5'"}]}}
 
 
 class TestJob:


### PR DESCRIPTION
The `*` asterisk is a special character in yaml, and therefore strings using it should be surrounded by quotes, as in the [Github Actions documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule:~:text=on%3A%0A%20%20schedule%3A%0A%20%20%20%20%23%20*%20is%20a%20special%20character%20in%20YAML%20so%20you%20have%20to%20quote%20this%20string%0A%20%20%20%20%2D%20cron%3A%20%20%2730%205%2C17%20*%20*%20*%27). Currently, GADK generates cron expressions without quotes, which could possibly lead to errors due to the use of asterisks. This corrects that by generating single quotes around cron expressions.