### PR TITLE
gadk: Support top level `permissions` element

### DIFF
--- a/gadk/elements.py
+++ b/gadk/elements.py
@@ -43,6 +43,8 @@ class Expression(Yamlable):
 
 EnvVars = Mapping[str, Union[Any, Expression]]
 
+Permissions = Mapping[str, Literal["read", "write", "none"]]
+
 
 class On(Yamlable):
     def __init__(
@@ -347,6 +349,7 @@ class Workflow(Yamlable):
         env: Optional[EnvVars] = None,
         concurrency_group: Optional[str] = None,
         cancel_in_progress: Optional[Union[bool, str, Expression]] = None,
+        permissions: Optional[Permissions] = None,
     ) -> None:
         if cancel_in_progress is not None and concurrency_group is None:
             raise ValueError(
@@ -361,6 +364,7 @@ class Workflow(Yamlable):
         self.cancel_in_progress: Optional[
             Union[bool, str, Expression]
         ] = cancel_in_progress
+        self.permissions = permissions
         self._on: Dict[str, Any] = {}
         self.jobs: Dict[str, Job] = {}
 
@@ -413,6 +417,8 @@ class Workflow(Yamlable):
                     if isinstance(self.cancel_in_progress, Yamlable)
                     else self.cancel_in_progress,
                 }
+        if self.permissions:
+            workflow["permissions"] = self.permissions
         workflow["on"] = {
             on_key: on.to_yaml() if isinstance(on, Yamlable) else on
             for on_key, on in self._on.items()

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -45,6 +45,16 @@ class TestWorkflow:
             "on": {},
         }
 
+    def test_permissions(self):
+        workflow = Workflow("foo", permissions={"id-token": "write", "contents": "read"})
+        assert workflow.to_yaml() == {
+            "permissions": {
+                "contents": "read",
+                "id-token": "write",
+            },
+            "on": {},
+        }
+
 
 class TestWorkflowOn:
     def test_on_only_push(self):


### PR DESCRIPTION
The permissions can be set within specific jobs to have the changes apply only to that job. This adds support only for the top-level key which apply to the whole workflow ([docs]).

[docs]: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions

Tests don't appear to be run in CI in this repo. They run successfully locally:
```
==================== test session starts ====================
platform linux -- Python 3.13.1, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/josh/repos/gadk
configfile: pyproject.toml
collected 47 items

tests/unit/test_elements.py ......................... [ 53%]
.....................                                 [ 97%]
tests/unit/test_utils.py .                            [100%]

==================== 47 passed in 0.06s =====================

```