### PR TITLE
Update 3rd party actions to latest versions

### DIFF
--- a/gadk/constants.py
+++ b/gadk/constants.py
@@ -1,5 +1,5 @@
 __all__ = ["ACTION_CHECKOUT", "ACTION_DOWNLOAD", "ACTION_UPLOAD"]
 
-ACTION_CHECKOUT = "actions/checkout@v4"
-ACTION_DOWNLOAD = "actions/download-artifact@v4"
+ACTION_CHECKOUT = "actions/checkout@v5"
+ACTION_DOWNLOAD = "actions/download-artifact@v5"
 ACTION_UPLOAD = "actions/upload-artifact@v4"


### PR DESCRIPTION
The only breaking changes in this major version update are
- [`actions/download-artifact`](https://github.com/actions/download-artifact/releases/tag/v5.0.0) - path changes when using `artifact-ids` to identify an artefact, which I can't find any use of in our code, and
- [`actions/checkout`](https://github.com/actions/checkout/releases/tag/v5.0.0) - minimal compatible runner verions, of which we use the latest available version already.

This is necessary to perform the [upgrade attempted by renovate](https://github.com/Piclo/flex/pull/16772) properly and completely.